### PR TITLE
Adding newExpOffByDefault feature (client side)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,8 @@ var _settings = exports._settings = {
   // a set interval, based on the cron-job configuration
   cronJob: null,
 
+  // Bool - `true` defaults the experiment state to OFF for new experiments
+  newExpOffByDefault: false,
 };
 
 /**
@@ -234,6 +236,7 @@ function _getExperimentFetcher(sendData) {
 
     request
       .set('x-feature-key', _settings.devKey)
+      .set('x-feature-default-exp-off', _settings.newExpOffByDefault)
       .on('error', function(err) {
         debug('Feature fetch err: ', err);
 


### PR DESCRIPTION
This new 'newExpOffByDefault' setting defaults the experiment state to OFF for new experiments. 

By default, this new settings is set to **`false`** (which is mimics the current behavior). This feature is turned on by explicitly setting this to **`true`** in the settings passed into the feature-client (such as "featureConfig").

This setting is passed to the _feature_ server 

_(see https://github.com/XPRMNTL/feature/pull/2)_
