### PR TITLE
Catch Request Errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,7 +246,10 @@ function _getExperimentFetcher(sendData) {
     if (_settings.timeout) request.timeout(_settings.timeout);
     if (_settings.sharedDevKey) request.set('x-feature-key-shared', _settings.sharedDevKey);
 
-    request.end(function(resp) {
+    request.end(function(error, resp) {
+      if (error) {
+        return dfdFail(error);
+      }
       if (resp.status !== 200) {
         var err = new Error('Something went wrong: ', resp.status);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node.js client for consumption of XPRMNTL Feature",
   "main": "./lib/index.js",
   "author": "Dan Crews <crewsd@gmail.com>",


### PR DESCRIPTION
* Add better error handling.
* Bump version.

When superagent request returns an error, we need to catch it.